### PR TITLE
Update cm.yaml

### DIFF
--- a/services/nutanix-ai/1.0.0/defaults/cm.yaml
+++ b/services/nutanix-ai/1.0.0/defaults/cm.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nutanix-ai-1.0.0-d2iq-defaults
-  namespace: nai-system
+  namespace: ${releaseNamespace}
 data:
   values.yaml: ""


### PR DESCRIPTION
all the default config maps needs to be present in existing workspace namespace. helmrelease refers to it and since nai-system is not yet created, it fails to deploy helmrelease.