### PR TITLE
Update nutanix-ai.yaml with latest nai release image tag

### DIFF
--- a/services/nutanix-ai/1.0.0/nutanix-ai.yaml
+++ b/services/nutanix-ai/1.0.0/nutanix-ai.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: nutanix.github.io-helm-releases
         namespace: ${workspaceNamespace}
-      version: 1.0.0-rc1
+      version: 1.0.0-rc2
   interval: 15s
   install:
     remediation:


### PR DESCRIPTION
rc1 was EA and its expired hence NAI team has requested to use rc2 version for testing