### PR TITLE
NCN-102997: Enable blackduck scan on nkp-nutanix-products-catalog repo

### DIFF
--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -1,0 +1,30 @@
+
+name: Black Duck Daily Policy Check
+on:
+  schedule:
+    - cron: "0 0 * * *" # Midnight
+jobs:
+  security:
+    if: github.repository == 'nutanix-cloud-native/cluster-api-provider-nutanix'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install devbox
+        run: curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f
+
+      - name: Install devbox deps
+        run: devbox install
+
+      - name: Build Project
+        run: devbox run -- make build
+
+      - name: Black Duck Full Scan
+        uses: synopsys-sig/synopsys-action@v1.10.0
+        with:
+          blackduck_url: ${{ secrets.BLACKDUCK_URL }}
+          blackduck_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          blackduck_scan_full: true
+          blackduck_scan_failure_severities: 'BLOCKER,CRITICAL'

--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -10,15 +10,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install devbox
-        run: curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f
-
-      - name: Install devbox deps
-        run: devbox install
-
-      - name: Build Project
-        run: devbox run -- make build
-
       - name: Black Duck Full Scan
         uses: synopsys-sig/synopsys-action@v1.10.0
         with:

--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -5,7 +5,7 @@ on:
     - cron: "0 0 * * *" # Midnight
 jobs:
   security:
-    if: github.repository == 'nutanix-cloud-native/cluster-api-provider-nutanix'
+    if: github.repository == 'nutanix-cloud-native/nkp-nutanix-product-catalog'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -1,8 +1,7 @@
 
 name: Black Duck Daily Policy Check
 on:
-  schedule:
-    - cron: "0 0 * * *" # Midnight
+  workflow_dispatch: # Enables manual triggering of the workflow
 jobs:
   security:
     if: github.repository == 'nutanix-cloud-native/nkp-nutanix-product-catalog'


### PR DESCRIPTION
Enable blackduck scan on nkp-nutanix-products-catalog repo

Reference change: https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/.github/workflows/synopsys-schedule.yaml