### PR TITLE
NCN-105308: Remove the certified certification under metadata.yaml

### DIFF
--- a/services/nutanix-ai/metadata.yaml
+++ b/services/nutanix-ai/metadata.yaml
@@ -5,7 +5,6 @@ allowMultipleInstances: false
 category:
   - artificial-intelligence
 certifications:
-  - certified
   - supported
   - airgapped
 licensing:


### PR DESCRIPTION
Need to remove the certified certification from https://github.com/nutanix-cloud-native/nkp-nutanix-product-catalog/blob/main/services/nutanix-ai/metadata.yaml#L8.

From the UX team,

NAI should only has Nutanix Support badge, same to the Insights App
Nutanix Apps: Insights, NAI ->Nutanix Support badge
Other third-party Appys -> Nutanix Qualified badge

https://nutanix.slack.com/archives/C069ZH0EB4N/p1737064035340629?thread_ts=1737061972.880659&channel=C069ZH0EB4N&message_ts=1737064035.340629