### PR TITLE
NCN-105920: Create the helm chart for NAI 2.1.0 deployment

### DIFF
--- a/services/nutanix-ai/2.0.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/services/nutanix-ai/2.0.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
   annotations:
-    "kustomize.toolkit.fluxcd.io/ssa": "IfNotPresent"
+    "kustomize.toolkit.fluxcd.io/ssa": "Merge"
 data:
   name: "Nutanix Enterprise AI"
   dashboardLink: "https://<ip_or_fqdn_istio_ingress_svc>/"

--- a/services/nutanix-ai/2.1.0/defaults/cm.yaml
+++ b/services/nutanix-ai/2.1.0/defaults/cm.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nutanix-ai-2.1.0-nkp-defaults
+  namespace: ${workspaceNamespace}
+data:
+  values.yaml: ""

--- a/services/nutanix-ai/2.1.0/defaults/kustomization.yaml
+++ b/services/nutanix-ai/2.1.0/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/nutanix-ai/2.1.0/helmreleases/kustomization.yaml
+++ b/services/nutanix-ai/2.1.0/helmreleases/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nai-ui-dashboard-cm.yaml
+- nutanix-ai.yaml

--- a/services/nutanix-ai/2.1.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/services/nutanix-ai/2.1.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nai-ui
+  namespace: ${workspaceNamespace}
+  labels:
+    "kommander.d2iq.io/application": "nutanix-ai"
+  annotations:
+    "kustomize.toolkit.fluxcd.io/ssa": "IfNotPresent"
+data:
+  name: "Nutanix Enterprise AI"
+  dashboardLink: "https://<ip_or_fqdn_istio_ingress_svc>/"
+  docsLink: "https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Enterprise-AI-v2_1:Nutanix-Enterprise-AI-v2_1"
+  version: "2.1.0"

--- a/services/nutanix-ai/2.1.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/services/nutanix-ai/2.1.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
   annotations:
-    "kustomize.toolkit.fluxcd.io/ssa": "IfNotPresent"
+    "kustomize.toolkit.fluxcd.io/ssa": "Merge"
 data:
   name: "Nutanix Enterprise AI"
   dashboardLink: "https://<ip_or_fqdn_istio_ingress_svc>/"

--- a/services/nutanix-ai/2.1.0/helmreleases/nutanix-ai.yaml
+++ b/services/nutanix-ai/2.1.0/helmreleases/nutanix-ai.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nutanix-ai
+  namespace: ${workspaceNamespace}
+spec:
+  dependsOn:
+    - name: kserve
+      namespace: ${workspaceNamespace}
+    - name: kserve-crd
+      namespace: ${workspaceNamespace}
+  chart:
+    spec:
+      chart: nai-core
+      sourceRef:
+        kind: HelmRepository
+        name: nutanix.github.io-helm-releases
+        namespace: ${workspaceNamespace}
+      version: 2.1.0
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: nutanix-ai
+  valuesFrom:
+    - kind: ConfigMap
+      name: nutanix-ai-2.1.0-nkp-defaults
+  targetNamespace: nai-system

--- a/services/nutanix-ai/2.1.0/kustomization.yaml
+++ b/services/nutanix-ai/2.1.0/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pre-install
+  - ./prerequisites
+  - ./helmreleases
+  - ../../../helm-repositories/ntnx-charts

--- a/services/nutanix-ai/2.1.0/metadata.yaml
+++ b/services/nutanix-ai/2.1.0/metadata.yaml
@@ -1,0 +1,2 @@
+# This is meant for e2e testing and not for production use
+k8sVersionSupport: ">=1.30"

--- a/services/nutanix-ai/2.1.0/pre-install/kustomization.yaml
+++ b/services/nutanix-ai/2.1.0/pre-install/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nai-self-signed-cert.yaml

--- a/services/nutanix-ai/2.1.0/pre-install/nai-self-signed-cert.yaml
+++ b/services/nutanix-ai/2.1.0/pre-install/nai-self-signed-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nai-self-signed-cert
+  namespace: istio-system
+spec:
+  secretName: nai-self-signed-cert
+  commonName: nai.example.com
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+  - nai.example.com

--- a/services/nutanix-ai/2.1.0/prerequisites/kserve-crd.yaml
+++ b/services/nutanix-ai/2.1.0/prerequisites/kserve-crd.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: ghcr.io-kserve-charts-kserve-crd
+  namespace: ${workspaceNamespace}
+spec:
+  # TODO(takirala): This does not work in airgapped as of today as the url here is
+  # hardcoded and we do not accept any secretRef here. If/when NKP supports oci in 
+  # airgapped (2.14 hopefully) we need to parametrize the URL here as well as
+  # allow secret population here if configured.
+  url: oci://ghcr.io/kserve/charts/kserve-crd
+  ref:
+    tag: v0.14.0
+  interval: 10m
+  layerSelector:
+    mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+    operation: copy
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kserve-crd
+  namespace: ${workspaceNamespace}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ghcr.io-kserve-charts-kserve-crd
+    namespace: ${workspaceNamespace}
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kserve-crd
+  targetNamespace: kserve

--- a/services/nutanix-ai/2.1.0/prerequisites/kserve.yaml
+++ b/services/nutanix-ai/2.1.0/prerequisites/kserve.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: ghcr.io-kserve-charts-kserve
+  namespace: ${workspaceNamespace}
+spec:
+  url: oci://ghcr.io/kserve/charts/kserve
+  ref:
+    tag: v0.14.0
+  interval: 10m
+  layerSelector:
+    mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+    operation: copy
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kserve
+  namespace: ${workspaceNamespace}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ghcr.io-kserve-charts-kserve
+    namespace: ${workspaceNamespace}
+  dependsOn:
+  - name: kserve-crd
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kserve
+  targetNamespace: kserve
+  values:
+    kserve:
+      modelmesh:
+        enabled: false
+      controller:
+        image: docker.io/nutanix/nai-kserve-controller
+        tag: v0.14.0

--- a/services/nutanix-ai/2.1.0/prerequisites/kustomization.yaml
+++ b/services/nutanix-ai/2.1.0/prerequisites/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kserve-crd.yaml
+- kserve.yaml


### PR DESCRIPTION
create the helm chart for NAI 2.1.0 deployment.

Test result:
1. Clean install
2. Install NAI 2.1 
3. Check the deployment process behaves expected.
4. Check the NAI UI is accessible.

<img width="530" alt="Screenshot 2025-03-18 at 10 08 13 PM" src="https://github.com/user-attachments/assets/36274d36-0a73-439a-9915-cf17cd8c4c02" />

The deployment process of NAI 2.1.0 on NKP 2.14 has been tested and it is good to access the UI.
```
zihui.liu@C02F94FBML85 Desktop % k get kustomization -A | grep nutanix
kommander-default-workspace   nutanix-ai                                  53m   True    Applied revision: NCN-105920@sha1:8b04d886a9fa77a4ff015c090ad1752a45fa7bfb
kommander-default-workspace   nutanix-ai-2.1.0-defaults                   53m   True    Applied revision: NCN-105920@sha1:8b04d886a9fa77a4ff015c090ad1752a45fa7bfb
```

```
zihui.liu@C02F94FBML85 Desktop % k get pods -A | grep nai                      
nai-system                        nai-api-5bc49f5445-6pw74                                        1/1     Running     0            51m
nai-system                        nai-api-db-migrate-hvnmy-8vbwv                                  0/1     Completed   0            51m
nai-system                        nai-db-0                                                        1/1     Running     0            51m
nai-system                        nai-iep-model-controller-7fd4cfc5cc-zk2kf                       1/1     Running     0            51m
nai-system                        nai-ui-77b7b789d5-8z9q6                                         1/1     Running     0            51m
nai-system                        prometheus-nai-0                                                2/2     Running     0            51m
```

<img width="1906" alt="Screenshot 2025-03-18 at 10 07 36 PM" src="https://github.com/user-attachments/assets/a5b999bc-661e-4d9b-bff9-195302b3742c" />
