### PR TITLE
NCN-106328: Update to use the fully qualified Gateway

### DIFF
--- a/services/nutanix-ai/metadata.yaml
+++ b/services/nutanix-ai/metadata.yaml
@@ -98,7 +98,7 @@ overview: |-
 
   ### Patch the Istio Gateway to enable HTTPS
   ```
-  kubectl patch gateway knative-ingress-gateway -n knative-serving --type='merge' --patch '{
+  kubectl patch gateways.networking.istio.io knative-ingress-gateway -n knative-serving --type='merge' --patch '{
   "spec": {
     "selector": {
       "istio": "ingressgateway"


### PR DESCRIPTION
Update to use the fully qualified Gateway

Test: https://nutanix.slack.com/archives/C07BE8YTCMV/p1741984594117989

Will not affect the NKP 2.14 workflow since it refers to the [nkp-nutanix-product-catalog](https://github.com/nutanix-cloud-native/nkp-nutanix-product-catalog) main branch for NAI deployment.