### PR TITLE
fix: Fix the nai-ui configmap change reverted by Flux

### DIFF
--- a/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ${workspaceNamespace}
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
+    "kustomize.toolkit.fluxcd.io/reconcile": "disabled"
   annotations:
     "kustomize.toolkit.fluxcd.io/ssa": "Merge"
 data:


### PR DESCRIPTION
During testing of the automation process of the NAI deployment nai, I have noticed the nai-ui configmap changed by k8s job has been reverted by Flux.

Tested on the daily cluster and the issue has been fixed.
```
zihui.liu@K0X95YV6M2 Desktop % k get cm nai-ui -n kommander -o yaml
apiVersion: v1
data:
  dashboardLink: https://a229bac819faa47c487afa05d88824bf-1958040014.us-west-2.elb.amazonaws.com/
  docsLink: https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Enterprise-AI-v2_3:Nutanix-Enterprise-AI-v2_3
  name: Nutanix Enterprise AI
  version: 2.3.0
kind: ConfigMap
metadata:
  annotations:
    kustomize.toolkit.fluxcd.io/reconcile: disabled
    kustomize.toolkit.fluxcd.io/ssa: Merge
  creationTimestamp: "2025-08-05T18:33:55Z"
  labels:
    kommander.d2iq.io/application: nutanix-ai
    kustomize.toolkit.fluxcd.io/name: nutanix-ai
    kustomize.toolkit.fluxcd.io/namespace: kommander
  name: nai-ui
  namespace: kommander
  resourceVersion: "1412692"
  uid: 87a6fd8d-b89a-4e55-8dc9-e0c616b50552
```