### PR TITLE
fix: update reconcile to prevent CM reverted by Flux

### DIFF
--- a/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
   annotations:
-    "kustomize.toolkit.fluxcd.io/ssa": "Override"
+    "kustomize.toolkit.fluxcd.io/ssa": "IfNotPresent"
 data:
   name: "Nutanix Enterprise AI"
   dashboardLink: "https://<ip_or_fqdn_istio_ingress_svc>/"

--- a/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
   annotations:
-    "kustomize.toolkit.fluxcd.io/ssa": "Merge"
+    "kustomize.toolkit.fluxcd.io/ssa": "Override"
 data:
   name: "Nutanix Enterprise AI"
   dashboardLink: "https://<ip_or_fqdn_istio_ingress_svc>/"

--- a/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
   annotations:
-    "kustomize.toolkit.fluxcd.io/reconcile": "disabled"
     "kustomize.toolkit.fluxcd.io/ssa": "Merge"
 data:
   name: "Nutanix Enterprise AI"

--- a/applications/nutanix-ai/2.3.0/post-install/job.yaml
+++ b/applications/nutanix-ai/2.3.0/post-install/job.yaml
@@ -2,8 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nai-postinstall
-  annotations:
-    kustomize.toolkit.fluxcd.io/reconcile: "disabled"
 spec:
   backoffLimit: 3
   ttlSecondsAfterFinished: null
@@ -52,7 +50,7 @@ spec:
 
               PAYLOAD=$(printf '{"data": {"dashboardLink": "%s"}}' "$ENDPOINT")
 
-              kubectl patch --field-manager=flux-client-side-apply configmap nai-ui -n "$WORKSPACE_NAMESPACE" \
+              kubectl patch configmap nai-ui -n "$WORKSPACE_NAMESPACE" \
                 --type=merge -p "$PAYLOAD"
 
               echo "test only..."

--- a/applications/nutanix-ai/2.3.0/post-install/job.yaml
+++ b/applications/nutanix-ai/2.3.0/post-install/job.yaml
@@ -53,5 +53,4 @@ spec:
               kubectl patch configmap nai-ui -n "$WORKSPACE_NAMESPACE" \
                 --type=merge -p "$PAYLOAD"
 
-              echo "test only..."
               echo "Dashboard link updated successfully."

--- a/applications/nutanix-ai/2.3.0/post-install/job.yaml
+++ b/applications/nutanix-ai/2.3.0/post-install/job.yaml
@@ -50,7 +50,7 @@ spec:
 
               PAYLOAD=$(printf '{"data": {"dashboardLink": "%s"}}' "$ENDPOINT")
 
-              kubectl patch configmap nai-ui -n "$WORKSPACE_NAMESPACE" \
+              kubectl patch --field-manager=flux-client-side-apply configmap nai-ui -n "$WORKSPACE_NAMESPACE" \
                 --type=merge -p "$PAYLOAD"
 
               echo "Dashboard link updated successfully."

--- a/applications/nutanix-ai/2.3.0/post-install/job.yaml
+++ b/applications/nutanix-ai/2.3.0/post-install/job.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nai-postinstall
+  annotations:
+    kustomize.toolkit.fluxcd.io/reconcile: "disabled"
 spec:
   backoffLimit: 3
   ttlSecondsAfterFinished: null
@@ -53,4 +55,5 @@ spec:
               kubectl patch --field-manager=flux-client-side-apply configmap nai-ui -n "$WORKSPACE_NAMESPACE" \
                 --type=merge -p "$PAYLOAD"
 
+              echo "test only..."
               echo "Dashboard link updated successfully."


### PR DESCRIPTION
Currently the k8s job patch will be reverted by Flux and here is a fix to prevent the revert.

1. Greenfield: User could be able to create new nai-ui configmap with the ip or fqdn from istio

2. Brownfield: user could be able to use the existing nai-ui configmap with ip or fqdn and probably need to have a manual patch if the ip change for any reason.

Test Result from NKP 2.16-dev.22 release:
```
zihui.liu@K0X95YV6M2 Desktop % k get cm nai-ui -n kommander -o yaml
apiVersion: v1
data:
  dashboardLink: https://10.23.128.44/
  docsLink: https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Enterprise-AI-v2_3:Nutanix-Enterprise-AI-v2_3
  name: Nutanix Enterprise AI
  version: 2.3.0
kind: ConfigMap
metadata:
  annotations:
    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
  creationTimestamp: "2025-08-06T22:33:17Z"
  labels:
    kommander.d2iq.io/application: nutanix-ai
    kustomize.toolkit.fluxcd.io/name: nutanix-ai
    kustomize.toolkit.fluxcd.io/namespace: kommander
  name: nai-ui
  namespace: kommander
  resourceVersion: "259658"
  uid: f3d32880-a666-4082-b3de-a8a26c1f5500
```