### PR TITLE
fix: revert incorrect IfNotPresent ssa annotation

### DIFF
--- a/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
+++ b/applications/nutanix-ai/2.3.0/helmreleases/nai-ui-dashboard-cm.yaml
@@ -6,9 +6,8 @@ metadata:
   labels:
     "kommander.d2iq.io/application": "nutanix-ai"
   annotations:
-    "kustomize.toolkit.fluxcd.io/ssa": "IfNotPresent"
+    "kustomize.toolkit.fluxcd.io/ssa": "Merge"
 data:
   name: "Nutanix Enterprise AI"
-  dashboardLink: "https://<ip_or_fqdn_istio_ingress_svc>/"
   docsLink: "https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Enterprise-AI-v2_3:Nutanix-Enterprise-AI-v2_3"
   version: "2.3.0"


### PR DESCRIPTION
Reverts #52 

We should not use IfNotPResent as that would block the configmap from getting updated in future upgrades. Instead, we can drop the field that we don't need to manage from gitops source and then use `Merge` startegy so that clients (like `kubectl` in post install job) can update it however they like.