### PR TITLE
ci: Add crd to bloodhound config

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -20,6 +20,9 @@ additional_crds:
  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/refs/heads/main/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml
  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/refs/heads/main/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/refs/heads/main/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+ - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/heads/main/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+ - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/heads/main/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+ - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/heads/main/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
 
 # set values for substitution variables (e.g. ${releaseNamespace}) in the resources
 substitution_vars:


### PR DESCRIPTION
```
2025-08-27 03:10:00 ERR Error: K8s v1.33.0 | HelmRelease: nutanix-ai | gateway.networking.k8s.io/v1/GatewayClass nai-gatewayclass: unknown type    err=<nil>
2025-08-27 03:10:00 ERR Error: K8s v1.33.0 | HelmRelease: nutanix-ai | gateway.networking.k8s.io/v1/Gateway nai-ingress-gateway: unknown type    err=<nil>
2025-08-27 03:10:00 ERR Error: K8s v1.33.0 | HelmRelease: nutanix-ai | gateway.networking.k8s.io/v1beta1/HTTPRoute nai-httproute: unknown type    err=<nil>
2025-08-27 03:10:00 INF  ✗ K8s v1.33.0: validating
```