### PR TITLE
NAI-3141: bitnami/kubectl image to bitnamilegacy/kubectl

### DIFF
--- a/services/nutanix-ai/2.4.0/post-install/job.yaml
+++ b/services/nutanix-ai/2.4.0/post-install/job.yaml
@@ -12,7 +12,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install-nai-patch
-          image: bitnami/kubectl:1.30.5
+          image: bitnamilegacy/kubectl:1.30.5
           imagePullPolicy: IfNotPresent
           env:
             - name: WORKSPACE_NAMESPACE


### PR DESCRIPTION
Image bitnami/kubectl has been moved to new location, it is advised to use bitnamilegacy/kubectl as short term solution until https://jira.nutanix.com/browse/NCN-109900
Ref: https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000009oqP0AQ