### PR TITLE
fix: addressed minor nits and oci registry url in ndk catalog

### DIFF
--- a/applications/ndk/1.3.0/metadata.yaml
+++ b/applications/ndk/1.3.0/metadata.yaml
@@ -23,12 +23,13 @@ overview: |-
   - [Nutanix Data Services for Kubernetes](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Data-Services-for-Kubernetes-v1_3)
   
   ## Prerequisites and Configuration Guide
+  ### This application is supported only on NKP clusters backed by Nutanix Infrastructure. 
   ### Before you begin, ensure that you have a workload cluster running Kubernetes version >= 1.26.0 and CSI version 3.0 installed.
   ### Nutanix Data Services for Kubernetes 1.3.0 requires the following applications to be installed on the cluster:
   - cert-manager v1.13.0
   - csi v3.3.4 or higher
 
-  ### During enabling of Nutanix Enterprise AI application from UI, provide following configuration (MUST):
+  ### During enabling of Nutanix Data Services for Kubernetes from UI, provide following configuration (MUST):
   ```
   imageCredentials:
     # Name of the image pull secret

--- a/applications/ndk/1.3.0/metadata.yaml
+++ b/applications/ndk/1.3.0/metadata.yaml
@@ -29,7 +29,7 @@ overview: |-
   - cert-manager v1.13.0
   - csi v3.3.4 or higher
 
-  ### During enabling of Nutanix Data Services for Kubernetes from UI, provide following configuration (MUST):
+  ### While enabling Nutanix Data Services for Kubernetes from UI, provide following configuration (MUST):
   ```
   imageCredentials:
     # Name of the image pull secret
@@ -41,6 +41,7 @@ overview: |-
       password: 
       email:
   ```
+  ### TLS will be disabled by default. To enable TLS, please follow the section below.
   ### For using self-signed certificates (to be issued by existing cert-manager)
   ```
   tls:

--- a/applications/ndk/1.3.0/release/ndk.yaml
+++ b/applications/ndk/1.3.0/release/ndk.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m 
-  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/ndk"
+  url: "oci://ghcr.io/mesosphere/charts/ndk"
   ref:
     tag: 1.3.0
 ---


### PR DESCRIPTION
This PR addresses the following -
1. Handled a nit where NAI was getting mentioned in the metadata
2. Added a statement to highlight that this app is only for nutanix infra
3. Removed the variable from oci source url since absolute url is fine and there is no substitution done for this variable. https://github.com/nutanix-cloud-native/nkp-nutanix-product-catalog/pull/70#discussion_r2482938179

Jira: https://jira.nutanix.com/browse/NCN-110844