### PR TITLE
fix: remove source suffix from oci artifact

### DIFF
--- a/applications/ndk/1.3.0/release/ndk.yaml
+++ b/applications/ndk/1.3.0/release/ndk.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ndk-1.3.0-source
+  name: ndk-1.3.0-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m 
@@ -17,7 +17,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ndk-1.3.0-source
+    name: ndk-1.3.0-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:


### PR DESCRIPTION
Currently there is "source" suffix in OCIRepository object name which is not allowed as per
https://github.com/nutanix-cloud-native/nkp-catalog-cli/blob/a30d11d9ba6220e2c1afff68bba07761c1e0a92a/pkg/bloodhound/parser.go#L17-L19