### PR TITLE
fix(ndk): add enterprise license to metadata

### DIFF
--- a/applications/ndk/2.0.0/metadata.yaml
+++ b/applications/ndk/2.0.0/metadata.yaml
@@ -12,6 +12,7 @@ certifications:
 licensing:
   - Pro
   - Ultimate
+  - Enterprise
 dependencies:
   - cert-manager
 scope:


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

- `Nutanix Data Services For Kubernetes` is a bit mouthful if not redundant on Nutanix "Kubernetes" Platform.
- Also, added `Enterprise` to licensing model so that this displays properly on enterprise licensed clusters.