### PR TITLE
NAI-3432: using mesosphere/kubectl image

### DIFF
--- a/applications/envoy-gateway/1.5.0/metadata.yaml
+++ b/applications/envoy-gateway/1.5.0/metadata.yaml
@@ -3,7 +3,7 @@ displayName: Envoy Gateway
 description: Envoy Gateway is a Kubernetes-native API Gateway and reverse proxy control plane.
 type: nkp-catalog
 allowMultipleInstances: false
-nkpVersionSupport: ">=2.16.0 <2.17.0"
+nkpVersionSupport: ">=2.16.0 <2.18.0"
 category:
   - networking
 certifications:

--- a/applications/nutanix-ai/2.5.0/helmreleases/cm.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/cm.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nutanix-ai-2.5.0-nkp-defaults
+  namespace: ${workspaceNamespace}
+data:
+  values.yaml: |-
+    naiMonitoring:
+      opentelemetry:
+        common:
+          resources:
+            requests:
+              cpu: 0.1
+    nai-clickhouse-server:
+      clickhouse:
+        resources:
+          requests:
+            cpu: 2

--- a/applications/nutanix-ai/2.5.0/helmreleases/cm.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/cm.yaml
@@ -12,8 +12,3 @@ data:
           resources:
             requests:
               cpu: 0.1
-    nai-clickhouse-server:
-      clickhouse:
-        resources:
-          requests:
-            cpu: 2

--- a/applications/nutanix-ai/2.5.0/helmreleases/kustomization.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- cm.yaml
 - service-monitor-cm.yaml
 - nai-ui-dashboard-cm.yaml
 - nai-operators.yaml

--- a/applications/nutanix-ai/2.5.0/helmreleases/nutanix-ai.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/nutanix-ai.yaml
@@ -49,6 +49,8 @@ spec:
   releaseName: nutanix-ai
   valuesFrom:
     - kind: ConfigMap
+      name: nutanix-ai-2.5.0-nkp-defaults
+    - kind: ConfigMap
       name: service-monitor-defaults
   targetNamespace: nai-system
   postRenderers:

--- a/applications/nutanix-ai/2.5.0/post-install/apply-resources-job.yaml
+++ b/applications/nutanix-ai/2.5.0/post-install/apply-resources-job.yaml
@@ -12,15 +12,13 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: apply-resources
-          image: bitnamilegacy/kubectl:1.30.5
+          image: mesosphere/kubectl:v1.33.2-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: WORKSPACE_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: KUBECONFIG
-              value: /opt/bitnami/kubectl/.kube/config
             - name: MAX_RETRIES
               value: "5"
             - name: RETRY_DELAY

--- a/applications/nutanix-ai/2.5.0/post-install/job.yaml
+++ b/applications/nutanix-ai/2.5.0/post-install/job.yaml
@@ -12,15 +12,13 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install-nai-patch
-          image: bitnamilegacy/kubectl:1.30.5
+          image: mesosphere/kubectl:v1.33.2-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: WORKSPACE_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: KUBECONFIG
-              value: /opt/bitnami/kubectl/.kube/config
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
Resolves - NAI-3432

- using mesosphere/kubectl image instead of bitnamilegacy
- Updated nai configmap to override cpu value for otel-collector and clickhouse server

<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->
