### PR TITLE
refactor: use correct naming for 2.16 and 2.17 compatibility

### DIFF
--- a/applications/envoy-gateway/1.5.0/helmrelease/envoy-gateway.yaml
+++ b/applications/envoy-gateway/1.5.0/helmrelease/envoy-gateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: envoy-gateway-1.5.0
+  name: ${releaseName}-1.5.0-chart
   namespace: ${workspaceNamespace}
 spec:
   url: oci://docker.io/envoyproxy/gateway-helm
@@ -22,7 +22,7 @@ spec:
   interval: 15s
   chartRef:
     kind: OCIRepository
-    name: envoy-gateway-1.5.0
+    name: ${releaseName}-1.5.0-chart
     namespace: ${workspaceNamespace}
   install:
     crds: Skip

--- a/applications/kserve/0.15.0/helmrelease/kserve-crd.yaml
+++ b/applications/kserve/0.15.0/helmrelease/kserve-crd.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: kserve-crd-0.15.0
+  name: ${releaseName}-crd-0.15.0-chart
   namespace: ${workspaceNamespace}
 spec:
   url: oci://ghcr.io/kserve/charts/kserve-crd
@@ -21,7 +21,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: kserve-crd-0.15.0
+    name: ${releaseName}-crd-0.15.0-chart
     namespace: ${workspaceNamespace}
   interval: 15s
   install:

--- a/applications/kserve/0.15.0/helmrelease/kserve.yaml
+++ b/applications/kserve/0.15.0/helmrelease/kserve.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: kserve-0.15.0
+  name: ${releaseName}-0.15.0-chart
   namespace: ${workspaceNamespace}
 spec:
   url: oci://ghcr.io/kserve/charts/kserve
@@ -21,7 +21,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: kserve-0.15.0
+    name: ${releaseName}-0.15.0-chart
     namespace: ${workspaceNamespace}
   dependsOn:
   - name: kserve-crd

--- a/applications/nutanix-ai/2.4.0/helmreleases/nutanix-ai.yaml
+++ b/applications/nutanix-ai/2.4.0/helmreleases/nutanix-ai.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: nutanix-ai
+  name: nutanix-ai-2.4.0-chart
   namespace: ${workspaceNamespace}
 spec:
   interval: 1m
@@ -22,7 +22,7 @@ spec:
       namespace: ${workspaceNamespace}
   chartRef:
     kind: OCIRepository
-    name: nutanix-ai
+    name: nutanix-ai-2.4.0-chart
     namespace: ${workspaceNamespace}
   interval: 15s
   install:

--- a/applications/nutanix-ai/2.4.0/helmreleases/nutanix-ai.yaml
+++ b/applications/nutanix-ai/2.4.0/helmreleases/nutanix-ai.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: nutanix-ai-2.4.0-chart
+  name: ${releaseName}-2.4.0-chart
   namespace: ${workspaceNamespace}
 spec:
   interval: 1m
@@ -22,7 +22,7 @@ spec:
       namespace: ${workspaceNamespace}
   chartRef:
     kind: OCIRepository
-    name: nutanix-ai-2.4.0-chart
+    name: ${releaseName}-2.4.0-chart
     namespace: ${workspaceNamespace}
   interval: 15s
   install:

--- a/applications/nutanix-ai/2.5.0/helmreleases/nai-operators.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/nai-operators.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-2.5.0-chart
+  name: ${releaseName}-nai-operators-2.5.0-chart
   namespace: ${workspaceNamespace}
 spec:
   interval: 1m
@@ -21,7 +21,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-2.5.0-chart
+    name: ${releaseName}-nai-operators-2.5.0-chart
     namespace: ${workspaceNamespace}
   dependsOn:
     - name: kserve

--- a/applications/nutanix-ai/2.5.0/helmreleases/nai-operators.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/nai-operators.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: nai-operators-2.5.0
+  name: ${releaseName}-2.5.0-chart
   namespace: ${workspaceNamespace}
 spec:
   interval: 1m
@@ -21,7 +21,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: nai-operators-2.5.0
+    name: ${releaseName}-2.5.0-chart
     namespace: ${workspaceNamespace}
   dependsOn:
     - name: kserve

--- a/applications/nutanix-ai/2.5.0/helmreleases/nutanix-ai.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/nutanix-ai.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: nutanix-ai-2.5.0-chart
+  name: ${releaseName}-nutanix-ai-2.5.0-chart
   namespace: ${workspaceNamespace}
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
@@ -34,7 +34,7 @@ spec:
       namespace: ${workspaceNamespace}
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-2.5.0-chart
+    name: ${releaseName}-nutanix-ai-2.5.0-chart
     namespace: ${workspaceNamespace}
   interval: 15s
   install:

--- a/applications/nutanix-ai/2.5.0/helmreleases/nutanix-ai.yaml
+++ b/applications/nutanix-ai/2.5.0/helmreleases/nutanix-ai.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: nutanix-ai-2.5.0
+  name: nutanix-ai-2.5.0-chart
   namespace: ${workspaceNamespace}
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
@@ -34,7 +34,7 @@ spec:
       namespace: ${workspaceNamespace}
   chartRef:
     kind: OCIRepository
-    name: nutanix-ai-2.5.0
+    name: ${releaseName}-2.5.0-chart
     namespace: ${workspaceNamespace}
   interval: 15s
   install:

--- a/applications/opentelemetry-operator/0.93.0/helmrelease/opentelemetry.yaml
+++ b/applications/opentelemetry-operator/0.93.0/helmrelease/opentelemetry.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: opentelemetry-operator-0.93.0
+  name: ${releaseName}-0.93.0-chart
   namespace: ${workspaceNamespace}
 spec:
   url: oci://ghcr.io/open-telemetry/opentelemetry-helm-charts/opentelemetry-operator
@@ -21,7 +21,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: opentelemetry-operator-0.93.0
+    name: ${releaseName}-0.93.0-chart
     namespace: ${workspaceNamespace}
   interval: 15s
   install:


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-111505

<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

We need to have better documentation and better validation errors from our catalog CLI and that should be the long term solution to avoid issues like this. 
For now, I am just refactoring these things so that 2.17 can go thru.


```
 nkp validate catalog-repository --repo-dir .
 ∅ Validating user-inputs.yaml for envoy-gateway/1.5.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
 ∅ Validating user-inputs.yaml for kserve/0.15.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
 ∅ Validating user-inputs.yaml for ndk/2.0.0
 ✓ K8s [1.34.0]: Parsing resources
 ✓ K8s v1.34.0: Validating
 ∅ Validating user-inputs.yaml for nutanix-ai/2.4.0
 ✓ K8s [1.33.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ∅ Validating user-inputs.yaml for nutanix-ai/2.5.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
Deprecation: K8s v1.33.0 | 2.5.0 | HelmRelease: nutanix-ai | gateway.networking.k8s.io/v1alpha3/BackendTLSPolicy iam-proxy-backend-tls-policy, custom resource is deprecated
 ✓ K8s v1.33.0: Validating
Deprecation: K8s v1.34.0 | 2.5.0 | HelmRelease: nutanix-ai | gateway.networking.k8s.io/v1alpha3/BackendTLSPolicy iam-proxy-backend-tls-policy, custom resource is deprecated
 ✓ K8s v1.34.0: Validating
 ∅ Validating user-inputs.yaml for opentelemetry-operator/0.93.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
APP                     VERSION  METADATA  APP MANIFESTS  ERROR
envoy-gateway           1.5.0    ✓         ✓
kserve                  0.15.0   ✓         ✓
ndk                     2.0.0    ✓         ✓
nutanix-ai              2.4.0    ✓         ✓
                        2.5.0    ✓         ✓
opentelemetry-operator  0.93.0   ✓         ✓
Validation completed in 32.4 seconds
```
