### PR TITLE
fix: use static naming for matching patch target

### DIFF
--- a/applications/ndk/2.0.0/release/ndk.yaml
+++ b/applications/ndk/2.0.0/release/ndk.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ${releaseName}
+  name: ndk
   namespace: ${releaseNamespace}
 spec:
   chartRef:


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

AppDeployment Controller generates this patch 

```
  patches:
  - patch: |
      - op: replace
        path: /metadata/name
        value: ndk
      - op: add
        path: /metadata/labels
        value:
          kommander.d2iq.io/managed-by-kind: AppDeployment
      - op: add
        path: /spec/valuesFrom/-
        value:
          kind: ConfigMap
          name: ndk-config-overrides
    target:
      kind: HelmRelease
      name: ndk
```
which will work only if the name of the HR is static. 

We should catch errors like this in linter checks in future tbh - https://jira.nutanix.com/browse/NCN-111597 
