### PR TITLE
fix: update metadata correcting MTLS steps

### DIFF
--- a/applications/ndk/2.0.0/metadata.yaml
+++ b/applications/ndk/2.0.0/metadata.yaml
@@ -51,7 +51,7 @@ overview: |-
   tls:
     server:
       enable: true
-      clusterName: <name of NKP cluster>
+      clusterName: <Name of NKP cluster>
   ```
   ### For using a custom issuer (a pre-existing issuer in ntnx-system namespace)
   ```
@@ -70,11 +70,15 @@ overview: |-
       enable: true
       mode: "SECRET"
       secretName: <Name of pre-existing secret>
+      clusterName: <Name of NKP cluster>
   ```
-  ### For enabling MTLS between NDK intercom service running on source and replication kubernetes clusters, make sure that same certificate authority signs and issues certificates to NDK intercom service on primary and replication clusters.
+  ### For enabling MTLS between NDK intercom service running on source and replication kubernetes clusters, make sure that same certificate authority (CA) signs and issues certificates to NDK intercom service on primary and replication clusters.
   To configure MTLS, the following change in configuration should be made:
   ```
   tls:
     server:
       enableMTLS: true
+      mode: "SECRET"
+      secretName: <Name of pre-existing secret>
+      clusterName: <Name of NKP cluster>
   ```


### PR DESCRIPTION
Updated value override required to enable MTLS between two clusters

Reference : https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Data-Services-for-Kubernetes-v2_0:top-dataservices-install-mtls-cli-k8s-t.html

**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->
