### PR TITLE
chore: relax linter config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,9 @@ repos:
     rev: v0.19.1
     hooks:
       - id: gitlint
+        args: ["--ignore", "B1", "-c", "T1.line-length=200"]
       - id: gitlint-ci
+        args: ["--ignore", "B1", "-c", "T1.line-length=200"]
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:
@@ -45,7 +47,9 @@ repos:
         stages: [pre-commit]
         args: ["-s", "-i", "2"]
       - id: git-check
+        args: ["--allow-untracked"]
       - id: git-dirty
+        args: ["--allow-untracked"]
       - id: script-must-have-extension
         stages: [pre-commit]
         exclude: ^\.envrc$


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

Minor linter fixes.

- Missing commit body: Configured gitlint to ignore rule B1 (body-is-missing) for both gitlint and gitlint-ci hooks.
- Commit message line length: Set gitlint's title line length (T1.line-length) to 200 characters for both hooks.
- Untracked files: Added --allow-untracked arguments to the git-check and git-dirty hooks.
