### PR TITLE
Add GitHub workflow to build airgapped catalog bundle and push to S3

### DIFF
--- a/.github/workflows/build-airgapped-bundle.yaml
+++ b/.github/workflows/build-airgapped-bundle.yaml
@@ -1,0 +1,109 @@
+# Build airgapped catalog bundle and push to S3 (similar to Kommander release.s3)
+# Uses just commands for local testability. Requires manual approval before running.
+#
+# Setup: Create GitHub Environment "airgapped-bundle-release" with required reviewers for approval.
+# Add these secrets to the environment or repository:
+#   S3_ACCESS_KEY_ID           - S3 bucket access key (username)
+#   S3_SECRET_ACCESS_KEY       - S3 bucket secret key (password)
+#   S3_BUCKET                 - S3 bucket name
+#   S3_PATH                   - Path prefix in bucket (e.g., catalog-bundles/)
+#   S3_REGION                 - AWS region for S3 (e.g., us-east-1)
+#   NUTANIX_DOCKERHUB_USERNAME - Docker Hub username (pulling private images)
+#   NUTANIX_DOCKERHUB_PASSWORD - Docker Hub password
+#   S3_ENDPOINT_URL           - (Optional) For S3-compatible storage (e.g., MinIO)
+name: Build Airgapped Bundle
+
+on:
+  workflow_dispatch:
+    inputs:
+      collection_tag:
+        description: 'Collection tag for the bundle'
+        type: choice
+        required: true
+        default: '2.17'
+        options:
+          - '2.16'
+          - '2.17'
+          - 'custom'
+      collection_tag_custom:
+        description: 'Custom collection tag (used when collection tag is "custom")'
+        type: string
+        required: false
+        default: ''
+      apps:
+        description: 'Comma-separated app=version to include. Leave empty to bundle all apps (except skipped).'
+        type: string
+        required: false
+        default: ''
+      skip:
+        description: 'Comma-separated app=version to skip (default excludes nutanix-ai 2.4.0 and 2.5.0)'
+        type: string
+        required: false
+        default: 'nutanix-ai=2.4.0,nutanix-ai=2.5.0'
+
+jobs:
+  build-and-push:
+    name: Build and push airgapped bundle to S3
+    runs-on:
+      - self-hosted-nutanix-medium
+    environment: airgapped-bundle-release  # Add required reviewers for approval gate
+    permissions:
+      contents: read
+    env:
+      S3_BUCKET: ${{ secrets.S3_BUCKET }}
+      S3_PATH: ${{ secrets.S3_PATH }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+      S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install NIX
+        uses: cachix/install-nix-action@v31
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.13.0
+        with:
+          enable-cache: true
+          skip-nix-installation: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.NUTANIX_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NUTANIX_DOCKERHUB_PASSWORD }}
+
+      - name: Resolve collection tag
+        id: tag
+        run: |
+          if [ "${{ github.event.inputs.collection_tag }}" = "custom" ]; then
+            if [ -z "${{ github.event.inputs.collection_tag_custom }}" ]; then
+              echo "Error: Custom collection tag is required when 'custom' is selected"
+              exit 1
+            fi
+            echo "tag=${{ github.event.inputs.collection_tag_custom }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.collection_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build airgapped bundle
+        run: |
+          if [ -n "${{ github.event.inputs.apps }}" ]; then
+            devbox run -- just create-airgapped-bundle "${{ steps.tag.outputs.tag }}" "${{ github.event.inputs.apps }}"
+          else
+            devbox run -- just create-airgapped-bundle-skip "${{ steps.tag.outputs.tag }}" "${{ github.event.inputs.skip }}"
+          fi
+
+      - name: Push bundle to S3
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_PATH: ${{ secrets.S3_PATH }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+          S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+        run: devbox run -- just push-bundle-to-s3 "${{ steps.tag.outputs.tag }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .local
 .idea
 untracked/*
+*-airgapped.tar

--- a/devbox.json
+++ b/devbox.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
   "packages": [
     "actionlint@latest",
+    "awscli2@latest",
     "gettext@latest",
     "git@latest",
     "just@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -49,6 +49,70 @@
         }
       }
     },
+    "awscli2@latest": {
+      "last_modified": "2026-02-23T15:40:43Z",
+      "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97#awscli2",
+      "source": "devbox-search",
+      "version": "2.33.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7fs6pvb0zdzr5pwvjd56lcg4v50zm300-awscli2-2.33.2",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/mcjyd58vanwzgsdi6r47gp706g7is1kw-awscli2-2.33.2-dist"
+            }
+          ],
+          "store_path": "/nix/store/7fs6pvb0zdzr5pwvjd56lcg4v50zm300-awscli2-2.33.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/laxzjbgfpaprmrafrgr3sm2a741bjj6m-awscli2-2.33.2",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/22jvkfalayg0s810xy8al26bxg8y9536-awscli2-2.33.2-dist"
+            }
+          ],
+          "store_path": "/nix/store/laxzjbgfpaprmrafrgr3sm2a741bjj6m-awscli2-2.33.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5xcwq8mbylr3dwxkdjbxf3f0gr8gzb8p-awscli2-2.33.2",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/4xmpgna7g51r7gyhladf5cfdzgiji1dv-awscli2-2.33.2-dist"
+            }
+          ],
+          "store_path": "/nix/store/5xcwq8mbylr3dwxkdjbxf3f0gr8gzb8p-awscli2-2.33.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/03f0vsahckikf0xcnqig8mls25c01ga5-awscli2-2.33.2",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/z908n1mkn8a30dyfmcyf23dqjr2gnh6p-awscli2-2.33.2-dist"
+            }
+          ],
+          "store_path": "/nix/store/03f0vsahckikf0xcnqig8mls25c01ga5-awscli2-2.33.2"
+        }
+      }
+    },
     "gettext@latest": {
       "last_modified": "2025-07-22T02:38:50Z",
       "resolved": "github:NixOS/nixpkgs/83e677f31c84212343f4cc553bab85c2efcad60a#gettext",

--- a/just/release.just
+++ b/just/release.just
@@ -7,3 +7,77 @@ publish-artifacts registry collection-tag apps: nkp-cli
   tmpdir="$(mktemp -d)"
   "{{ NKP_CLI }}" create catalog-bundle --repo-dir "{{ REPO_ROOT }}" --collection-tag "{{collection-tag}}" --apps="{{apps}}" --output-file "$tmpdir/bundle.tar"
   "{{ NKP_CLI }}" push bundle --bundle "$tmpdir/bundle.tar" --to-registry "{{ registry }}"
+
+# Create airgapped catalog bundle (includes container images and OCI artifacts)
+# Usage: just create-airgapped-bundle <collection-tag> [apps]
+# Example: just create-airgapped-bundle v2.6.0 "nutanix-ai=2.6.0"
+# Example: just create-airgapped-bundle v2.6.0  (bundles all apps)
+[script]
+create-airgapped-bundle collection-tag apps="": nkp-cli
+  tmpdir="$(mktemp -d)"
+  if [ -n "{{apps}}" ]; then
+    "{{ NKP_CLI }}" create catalog-bundle --repo-dir "{{ REPO_ROOT }}" --collection-tag "{{collection-tag}}" --apps="{{apps}}" --airgapped --output-file "$tmpdir/bundle-airgapped.tar"
+  else
+    "{{ NKP_CLI }}" create catalog-bundle --repo-dir "{{ REPO_ROOT }}" --collection-tag "{{collection-tag}}" --airgapped --output-file "$tmpdir/bundle-airgapped.tar"
+  fi
+  mv "$tmpdir/bundle-airgapped.tar" "{{ REPO_ROOT }}/nutanix-product-catalog-{{collection-tag}}-airgapped.tar"
+  echo "Created {{ REPO_ROOT }}/nutanix-product-catalog-{{collection-tag}}-airgapped.tar"
+
+# Create airgapped bundle excluding specified app versions
+# Usage: just create-airgapped-bundle-skip <collection-tag> <skip>
+# Example: just create-airgapped-bundle-skip v2.6.0 "nutanix-ai=2.5.0"
+# Example: just create-airgapped-bundle-skip v2.6.0 "nutanix-ai=2.5.0,kserve=0.14.0"
+[script]
+create-airgapped-bundle-skip collection-tag skip: nkp-cli
+  apps_dir="{{ REPO_ROOT }}/applications"
+  all_apps=""
+  for app_dir in "$apps_dir"/*/; do
+    app="$(basename "$app_dir")"
+    for ver_dir in "$app_dir"*/; do
+      [ -d "$ver_dir" ] || continue
+      ver="$(basename "$ver_dir")"
+      all_apps="${all_apps}${app}=${ver},"
+    done
+  done
+  all_apps="${all_apps%,}"
+  skip_list="$(echo "{{skip}}" | tr ',' '\n' | tr -d ' ')"
+  include_apps=""
+  for item in $(echo "$all_apps" | tr ',' '\n'); do
+    skip=0
+    for s in $skip_list; do
+      [ "$item" = "$s" ] && skip=1 && break
+    done
+    [ $skip -eq 0 ] && include_apps="${include_apps}${item},"
+  done
+  include_apps="${include_apps%,}"
+  [ -z "$include_apps" ] && echo "No apps to bundle after skipping" && exit 1
+  just create-airgapped-bundle "{{collection-tag}}" "$include_apps"
+
+# Push airgapped bundle to S3 bucket (similar to Kommander release.s3)
+# Requires env vars: S3_BUCKET, S3_PATH (optional), AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# For S3-compatible (MinIO): also set S3_ENDPOINT_URL
+# Usage: just push-bundle-to-s3 <collection-tag>
+[script]
+push-bundle-to-s3 collection-tag:
+  bundle_file="{{ REPO_ROOT }}/nutanix-product-catalog-{{collection-tag}}-airgapped.tar"
+  if [ ! -f "$bundle_file" ]; then
+    echo "Bundle not found. Run: just create-airgapped-bundle {{collection-tag}} [apps]"
+    exit 1
+  fi
+  s3_path="${S3_PATH:-catalog-bundles/}"
+  s3_path="${s3_path%/}/"  # ensure trailing slash
+  s3_key="${s3_path}nutanix-product-catalog-{{collection-tag}}-airgapped.tar"
+  if [ -n "${S3_ENDPOINT_URL:-}" ]; then
+    aws s3 cp --endpoint-url "$S3_ENDPOINT_URL" --no-progress "$bundle_file" "s3://${S3_BUCKET}/${s3_key}"
+  else
+    aws s3 cp --no-progress "$bundle_file" "s3://${S3_BUCKET}/${s3_key}"
+  fi
+  echo "Published to s3://${S3_BUCKET}/${s3_key}"
+
+# Full pipeline: create airgapped bundle and push to S3
+# Usage: just publish-airgapped-bundle <collection-tag> [apps]
+publish-airgapped-bundle collection-tag apps="": (create-airgapped-bundle collection-tag apps) (push-bundle-to-s3 collection-tag)
+
+# Full pipeline: create airgapped bundle (excluding skip list) and push to S3
+# Usage: just publish-airgapped-bundle-skip <collection-tag> <skip>
+publish-airgapped-bundle-skip collection-tag skip: (create-airgapped-bundle-skip collection-tag skip) (push-bundle-to-s3 collection-tag)


### PR DESCRIPTION
- Add build-airgapped-bundle workflow with approval gate (environment)
- Create airgapped bundle via nkp CLI with --airgapped flag
- Push to S3 bucket (not OCI) using aws s3 cp, similar to Kommander
- Add Docker Hub login for ci user (private image pulls)
- Add just recipes: create-airgapped-bundle, push-bundle-to-s3, publish-airgapped-bundle
- Add awscli2 to devbox for local S3 push testing
- Add docs/airgapped-bundle-secrets.md with secrets reference



**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->
NCN-111669

<pre>
(devbox) ➜~/go/src/github.com/nutanix-cloud-native/nkp-nutanix-product-catalog ➜ git:(airgapped-ghaction) ✗ just create-airgapped-bundle-skip 2.17 "nutanix-ai=2.5.0,nutanix-ai=2.4.0" 
Bundling 7 application(s) (airgapped : true)
 ✓ Building OCI artifact nkp-nutanix-product-catalog/collection:2.17 
 ✓ Building OCI artifact nkp-nutanix-product-catalog/envoy-gateway:1.5.0 
 ✓ Building OCI artifact nkp-nutanix-product-catalog/envoy-gateway:1.6.3 
 ✓ Building OCI artifact nkp-nutanix-product-catalog/kserve:0.15.0 
 ✓ Building OCI artifact nkp-nutanix-product-catalog/ndk:2.0.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/nutanix-ai:2.6.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/opentelemetry-operator:0.102.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/opentelemetry-operator:0.93.0 

Processing application artifacts...
Processing application envoy-gateway/1.5.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources 
 ✓ K8s v1.33.0: Validating 
 ✓ K8s v1.34.0: Validating 
Processing application envoy-gateway/1.6.3
 ✓ K8s [1.33.0]: Parsing resources 
 ✓ K8s v1.33.0: Validating 
Processing application kserve/0.15.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources 
 ✓ K8s v1.33.0: Validating 
 ✓ K8s v1.34.0: Validating 
Processing application ndk/2.0.0
 ✓ K8s [1.34.0]: Parsing resources 
 ✓ K8s v1.34.0: Validating 
Processing application nutanix-ai/2.6.0
 ✓ K8s [1.33.0]: Parsing resources 
 ✓ K8s v1.33.0: Validating 
Processing application opentelemetry-operator/0.102.0
 ✓ K8s [1.33.0]: Parsing resources 
 ✓ K8s v1.33.0: Validating 
Processing application opentelemetry-operator/0.93.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources 
 ✓ K8s v1.33.0: Validating 
 ✓ K8s v1.34.0: Validating 
 ✓ Pulling requested images [==================================>48/48] (time elapsed 1m21s) 

Saving bundle...
 ✓ Saving application bundle to /var/folders/cn/fbgq3d4s1_g79t30nnp_p52h0000gp/T/tmp.fB8Ds8WL0j/bundle-airgapped.tar 

Run the following to push the artifact to your registry:

	nkp push bundle --bundle /var/folders/cn/fbgq3d4s1_g79t30nnp_p52h0000gp/T/tmp.fB8Ds8WL0j/bundle-airgapped.tar --to-registry <your-registry-url>


Run the following command to create catalog artifact(s) after pushing them:

	nkp create catalog-collection --url oci://<registry-url>/nkp-nutanix-product-catalog/collection --tag 2.17 --workspace kommander-workspace

Created /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/nkp-nutanix-product-catalog/nutanix-product-catalog-2.17-airgapped.tar
(devbox) ➜ ~/go/src/github.com/nutanix-cloud-native/nkp-nutanix-product-catalog ➜ git:(airgapped-ghaction) ✗ ls -ltrah nutanix-product-catalog-2.17-airgapped.tar
-rw-r--r-- 1 deepak.muley 1.6G Feb 26 20:28 nutanix-product-catalog-2.17-airgapped.tar

</pre>