### PR TITLE
chore: bump ndk to 2.1

### DIFF
--- a/.release/stable.yaml
+++ b/.release/stable.yaml
@@ -15,7 +15,7 @@ releases:
       - name: opentelemetry-operator
         version: "0.93.0"
       - name: ndk
-        version: "2.0.0"
+        version: "2.1.0"
   - tagName: 2.17
     fileName: stable-nkp-nutanix-product-catalog-2.17.tar
     applications:

--- a/.release/stable.yaml
+++ b/.release/stable.yaml
@@ -33,6 +33,8 @@ releases:
         version: "0.93.0"
       - name: ndk
         version: "2.0.0"
+      - name: ndk
+        version: "2.1.0"
   - tagName: 2.16
     fileName: stable-nkp-nutanix-product-catalog-2.16.tar
     applications:

--- a/applications/ndk/2.1.0/.bloodhound.yml
+++ b/applications/ndk/2.1.0/.bloodhound.yml
@@ -1,0 +1,12 @@
+# Kubernetes versions
+k8s_versions:
+  - 1.34.0
+  - 1.35.0
+
+# use strict validation (reject unknown fields in resources)
+strict: true
+
+# load additional CRDs (URLs of CRD yaml files)
+additional_crds:
+ - https://raw.githubusercontent.com/cert-manager/cert-manager/master/deploy/crds/cert-manager.io_certificates.yaml
+ - https://raw.githubusercontent.com/cert-manager/cert-manager/master/deploy/crds/cert-manager.io_issuers.yaml

--- a/applications/ndk/2.1.0/kustomization.yaml
+++ b/applications/ndk/2.1.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./release

--- a/applications/ndk/2.1.0/metadata.yaml
+++ b/applications/ndk/2.1.0/metadata.yaml
@@ -1,0 +1,84 @@
+schema: catalog.nkp.nutanix.com/v1/application-metadata
+displayName: Nutanix Data Services for Kubernetes
+description: Nutanix Data Services for Kubernetes
+type: nkp-catalog
+allowMultipleInstances: false
+nkpVersionSupport: ">=2.17.0 <2.19.0"
+category:
+  - application-and-data-management
+certifications:
+  - nutanix-supported
+  - airgapped
+licensing:
+  - Pro
+  - Ultimate
+dependencies:
+  - cert-manager
+scope:
+  - workspace
+icon: PHN2ZyB3aWR0aD0iNDgiIGhlaWdodD0iNDgiIHZpZXdCb3g9IjAgMCA0OCA0OCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzI2MTlfMTEwMzUpIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yOS45MjE2IDI1Ljk0NTZDMzAuMDY2MSAyNS45NDU2IDMwLjE5NjUgMjYuMDA4MyAzMC4yOTEzIDI2LjEwOTJMMzkuNzk0IDM0Ljk5MTNDMzkuOTE5MSAzNS4wOTQgMzkuOTk5OSAzNS4yNTU5IDM5Ljk5OTkgMzUuNDM4MUMzOS45OTk5IDM1Ljc0ODEgMzkuNzY1OSAzNS45OTk4IDM5LjQ3NzIgMzUuOTk5OEgzMy4wMDM4QzMyLjg2MTIgMzUuOTk5OCAzMi43MzE2IDM1LjkzODIgMzIuNjM3MyAzNS44Mzg0TDI2LjM0ODggMjkuOTYxNkMyNi4yMzQzIDI5Ljg1NzggMjYuMTYyMSAyOS43MDM5IDI2LjE2MjEgMjkuNTMxMUMyNi4xNjIxIDI5LjM4NTkgMjYuMjEzNiAyOS4yNTM2IDI2LjI5NzggMjkuMTUzOUwyOS41MzQ0IDI2LjEyOTJDMjkuNjMgMjYuMDE2NiAyOS43NjgxIDI1Ljk0NTYgMjkuOTIxNiAyNS45NDU2Wk0zOS40NzcyIDEyQzM5Ljc2NTkgMTIgMzkuOTk5OSAxMi4yNTE4IDM5Ljk5OTkgMTIuNTYxN0MzOS45OTk5IDEyLjc0MzkgMzkuOTE5MSAxMi45MDU2IDM5Ljc5NCAxMy4wMDgyTDMwLjI5MTMgMjEuODkwM0MzMC4xOTY1IDIxLjk5MTUgMzAuMDY2MSAyMi4wNTQzIDI5LjkyMTYgMjIuMDU0M0MyOS43NjgxIDIyLjA1NDMgMjkuNjMgMjEuOTgzNSAyOS41MzQ0IDIxLjg3MDZMMjYuMjk3OCAxOC44NDZDMjYuMjEzNiAxOC43NDYyIDI2LjE2MjEgMTguNjEzOSAyNi4xNjIxIDE4LjQ2ODdDMjYuMTYyMSAxOC4yOTYyIDI2LjIzNDMgMTguMTQyIDI2LjM0ODggMTguMDM4NUwzMi42MzczIDEyLjE2MTFDMzIuNzMxNiAxMi4wNjE2IDMyLjg2MTIgMTIgMzMuMDAzOCAxMkgzOS40NzcyWiIgZmlsbD0iIzc4NTVGQSIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE1LjM1NzUgMzUuODUyM0MxNS4yNjQ1IDM1Ljk0MzUgMTUuMTQwNSAzNiAxNS4wMDQzIDM2SDguNTIyNjVDOC4yMzM5NyAzNiA4IDM1Ljc0ODIgOCAzNS40MzhDOCAzNS4yODMyIDguMDU4NDMgMzUuMTQyOSA4LjE1Mjk3IDM1LjA0MTZMMTkuNTExMSAyNC40MjkxQzE5LjYyNSAyNC4zMjYyIDE5LjY5NzIgMjQuMTcxOSAxOS42OTcyIDIzLjk5OTRDMTkuNjk3MiAyMy44MzYzIDE5LjYzMjQgMjMuNjg5OCAxOS41Mjk0IDIzLjU4NzRMOC4xODUxMSAxMi45OUM4LjA3MTcxIDEyLjg4NyA4IDEyLjczMzYgOCAxMi41NjE3QzggMTIuMjUxOCA4LjIzMzk3IDEyIDguNTIyNjUgMTJIMTUuMDA0M0MxNS4xNDEgMTIgMTUuMjY1NiAxMi4wNTYyIDE1LjM1ODUgMTIuMTQ4M0wyNy41ODYxIDIzLjU3NTdDMjcuNjk2OSAyMy42Nzg0IDI3Ljc2NjcgMjMuODI5OCAyNy43NjY3IDIzLjk5OTRDMjcuNzY2NyAyNC4xNjk0IDI3LjY5NjYgMjQuMzIxOSAyNy41ODUzIDI0LjQyNTFMMTUuMzU3NSAzNS44NTIzWiIgZmlsbD0iIzc4NTVGQSIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzI2MTlfMTEwMzUiPgo8cmVjdCB3aWR0aD0iNDgiIGhlaWdodD0iNDgiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==
+overview: |-
+  # Overview
+  Nutanix Data Services for Kubernetes (NDK) simplifies and unifies the life cycle management of business-critical applications by extending enterprise data services to containerized applications.
+  ## For Information on Features
+  - [Nutanix Data Services for Kubernetes](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Data-Services-for-Kubernetes-v2_1:Nutanix-Data-Services-for-Kubernetes-v2_1)
+
+  ## Prerequisites and Configuration Guide
+  ### This application is supported only on NKP clusters backed by Nutanix Infrastructure.
+  ### Nutanix Data Services for Kubernetes 2.1 requires the following applications to be installed on the cluster:
+  - cert-manager v1.13.0 or higher
+  - csi v3.3.8 or higher
+
+  ### While enabling Nutanix Data Services for Kubernetes from UI, image pull credentials need to be provided. If the secret object already exists in ntnx-system namespace, it's reference can be provided:
+  ```
+  imageCredentials:
+    # Name of the image pull secret
+    imagePullSecretName: <name of the image pull secret>
+  ```
+  ### Or credentials can be provided with below configuration:
+  ```
+  imageCredentials:
+    # Image registry credentials
+    credentials:
+      registry: https://index.docker.io/v1/
+      username:
+      password:
+      email:
+  ```
+  ### TLS will be disabled by default. To enable TLS, please follow the section below.
+  ### For using self-signed certificates (to be issued by existing cert-manager)
+  ```
+  tls:
+    server:
+      enable: true
+      clusterName: <Name of NKP cluster>
+  ```
+  ### For using a custom issuer (a pre-existing issuer in ntnx-system namespace)
+  ```
+  tls:
+    server:
+      enable: true
+      mode: "ISSUER"
+      issuer:
+        issuerName: <issuer-name>
+      clusterName: <Name of NKP cluster>
+  ```
+  ### For using a custom Secret (a pre-existing secret in ntnx-system namespace)
+  ```
+  tls:
+    server:
+      enable: true
+      mode: "SECRET"
+      secretName: <Name of pre-existing secret>
+      clusterName: <Name of NKP cluster>
+  ```
+  ### For enabling MTLS between NDK intercom service running on source and replication kubernetes clusters, make sure that same certificate authority (CA) signs and issues certificates to NDK intercom service on primary and replication clusters.
+  To configure MTLS, the following change in configuration should be made:
+  ```
+  tls:
+    server:
+      enableMTLS: true
+      mode: "SECRET"
+      secretName: <Name of pre-existing secret>
+      clusterName: <Name of NKP cluster>
+  ```

--- a/applications/ndk/2.1.0/metadata.yaml
+++ b/applications/ndk/2.1.0/metadata.yaml
@@ -3,7 +3,7 @@ displayName: Nutanix Data Services for Kubernetes
 description: Nutanix Data Services for Kubernetes
 type: nkp-catalog
 allowMultipleInstances: false
-nkpVersionSupport: ">=2.17.0 <2.19.0"
+nkpVersionSupport: ">=2.18.0 <2.19.0"
 category:
   - application-and-data-management
 certifications:

--- a/applications/ndk/2.1.0/release/cm.yaml
+++ b/applications/ndk/2.1.0/release/cm.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${releaseName}-${appVersion}-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |-
+    manager:
+      repository: docker.io/nutanix/ndk-manager
+      pullPolicy: IfNotPresent
+    infraManager:
+      repository: docker.io/nutanix/ndk-infra-manager
+      pullPolicy: IfNotPresent
+    kubeRbacProxy:
+      repository: docker.io/nutanix/kube-rbac-proxy
+      tag: v0.19.0
+      pullPolicy: IfNotPresent
+    jobScheduler:
+      repository: docker.io/nutanix/ndk-job-scheduler
+      pullPolicy: IfNotPresent
+    kubectl:
+      repository: docker.io/nutanix/kubectl
+      tag: 1.32.3
+      pullPolicy: IfNotPresent
+    # Set Values for NDK Metrics Monitoring using Prometheus
+    prometheus:
+      # Requires Prometheus Operator CRDs
+      enable: false
+      # Set values for Prometheus serviceMonitor
+      serviceMonitor:
+        # Add Custom labels for serviceMonitor here
+        customLabels: {}
+    tls:
+      webhook:
+        # By default, the webhook will be configured to use a self-signed certificate orchestrated by default cert-manager.
+        mode: "SELF_SIGNED"
+      server:
+        # By default, TLS will be disabled for the NDK server.
+        enable: false
+        # By default, mTLS will be disabled for the NDK server.
+        enableMTLS: false
+        mode: "SELF_SIGNED"
+    config:
+      # To provide secret to be used by controllers for storage backend authentication
+      # @Required-- secret should be in the helm release namespace
+      secret:
+        # pointer to the secret to be consumed by controllers
+        name: nutanix-csi-credentials

--- a/applications/ndk/2.1.0/release/kustomization.yaml
+++ b/applications/ndk/2.1.0/release/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+  - ndk.yaml

--- a/applications/ndk/2.1.0/release/ndk.yaml
+++ b/applications/ndk/2.1.0/release/ndk.yaml
@@ -1,0 +1,34 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ${releaseName}-${appVersion}-chart
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "oci://ghcr.io/mesosphere/charts/ndk"
+  ref:
+    tag: 2.1.0
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ndk
+  namespace: ${releaseNamespace}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ${releaseName}-${appVersion}-chart
+    namespace: ${releaseNamespace}
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: false # Since "ntnx-system" namespace is already created during csi installation.
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: ndk
+  valuesFrom:
+    - kind: ConfigMap
+      name: ${releaseName}-${appVersion}-defaults
+  targetNamespace: ntnx-system


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
 - Bumping NDK chart to 2.1
 
 *** Action to Publish OCI Artifacts***:
 https://github.com/mesosphere/kommander-applications/actions/runs/23483674567/job/68333599698
 
 *** Dev Testing Screenshots ***
<img width="908" height="543" alt="Screenshot 2026-03-26 at 9 38 38 AM" src="https://github.com/user-attachments/assets/a25d56f2-327b-4e75-b146-7cf781323b7e" />

<img width="778" height="157" alt="Screenshot 2026-03-26 at 1 12 14 PM" src="https://github.com/user-attachments/assets/16b4c5ee-aceb-4723-b498-6c6826d3476d" />
<img width="855" height="145" alt="Screenshot 2026-03-26 at 1 13 13 PM" src="https://github.com/user-attachments/assets/8a0797f7-be2c-4397-8fb7-f91274f9057e" />

<img width="756" height="114" alt="Screenshot 2026-03-26 at 1 13 54 PM" src="https://github.com/user-attachments/assets/36fcf8a0-6938-4d0d-9631-6c684dc82042" />
<img width="863" height="103" alt="Screenshot 2026-03-26 at 1 14 43 PM" src="https://github.com/user-attachments/assets/25948a04-97cf-45a9-9f92-b21b190163b5" />

- Brownfield

https://github.com/user-attachments/assets/f5df540f-cfbb-4f40-aebb-96f373e94e9e

