### PR TITLE
fix: correct typo in metadata.yaml configuration syntax

### DIFF
--- a/applications/nutanix-ai/2.6.0/metadata.yaml
+++ b/applications/nutanix-ai/2.6.0/metadata.yaml
@@ -81,7 +81,7 @@ overview: |-
 
   ### During enabling of Nutanix Enterprise AI application from UI, provide following configuration:
   ```
-  global::
+  global:
     imagePullSecrets:
       - name: nai-regcred
   ```


### PR DESCRIPTION
This pull request makes a minor formatting correction to the `metadata.yaml` file for the Nutanix Enterprise AI application. The change ensures the YAML syntax for the `global` configuration is correct by removing an unnecessary colon.

- Fixed YAML formatting by changing `global::` to `global:` in the configuration example in `metadata.yaml`.