### PR TITLE
fix: use stripped tag

### DIFF
--- a/just/release.just
+++ b/just/release.just
@@ -28,10 +28,11 @@ create-airgapped-bundle collection-tag output-file release-spec=".release/stable
   cp {{ REPO_ROOT }}/.release/airgapped.yaml.tmpl "$tmpfile"
 
   yq -i \
-    '.releases[0].tagName = "{{collection-tag}}" |
+    '.releases[0].tagName = "'$tag_version'" |
      .releases[0].fileName = "{{output-file}}" |
      .releases[0].applications = (load("{{release-spec}}") | .releases[] | select(.tagName == "'$tag_version'") | .applications)' \
     "$tmpfile"
 
-  echo "Building airgapped bundle for {{collection-tag}}..."
+  echo "Building airgapped bundle for $tag_version..."
+  cat "$tmpfile"
   "{{ NKP_CLI }}" experimental catalog release --release-spec "$tmpfile" --repo-dir "{{ REPO_ROOT }}"


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

Fixes https://github.com/mesosphere/bundle/actions/runs/25202528452

I was using `collection-tag` instead of stripped `tag-version` in the just recipe. Tested this locally:
```
❯ just create-airgapped-bundle v2.18.0-dev.30 my.tar
Building airgapped bundle for 2.18...
# Airgapped release spec template
schema: catalog.nkp.nutanix.com/v1/catalog-release-spec
releases:
  - tagName: "2.18"
    fileName: my.tar
    includeApplicationImages: true
    baseRegistry: ghcr.io/nutanix-cloud-native
    applications:
      - name: nutanix-ai
        version: "2.6.0"
      - name: kserve
        version: "0.15.0"
      - name: envoy-gateway
        version: "1.5.0"
      - name: envoy-gateway
        version: "1.6.3"
      - name: opentelemetry-operator
        version: "0.93.0"
      - name: ndk
        version: "2.1.0"
Building airgapped bundle "2.18" (6 application(s)) -> /Users/tarun.akirala/git/organizations/nutanix-cloud-native/nkp-nutanix-product-catalog/my.tar
 ✓ Building OCI artifact nkp-nutanix-product-catalog/collection:2.18
 ✓ Building OCI artifact nkp-nutanix-product-catalog/nutanix-ai:2.6.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/kserve:0.15.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/envoy-gateway:1.5.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/envoy-gateway:1.6.3
 ✓ Building OCI artifact nkp-nutanix-product-catalog/opentelemetry-operator:0.93.0
 ✓ Building OCI artifact nkp-nutanix-product-catalog/ndk:2.1.0

Processing application artifacts...
Processing application nutanix-ai/2.6.0
 ✓ K8s [1.33.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
Processing application kserve/0.15.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
Processing application envoy-gateway/1.5.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
Processing application envoy-gateway/1.6.3
 ✓ K8s [1.33.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
Processing application opentelemetry-operator/0.93.0
 ✓ K8s [1.33.0 1.34.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
Processing application ndk/2.1.0
 ✓ K8s [1.34.0 1.35.0]: Parsing resources
 ✓ K8s v1.34.0: Validating
 ✓ K8s v1.35.0: Validating
 ✗ Pulling requested images [===>                                4/44] (time elapsed 10s)
release "2.18": build airgapped bundle: failed to pull images and oci artifacts: failed to get image "docker.io/nutanix/kube-rbac-proxy:v0.19.0": failed to read image descriptor for "docker.io/nutanix/kube-rbac-proxy:v0.19.0" from registry: GET https://index.docker.io/v2/nutanix/kube-rbac-proxy/manifests/v0.19.0: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:nutanix/kube-rbac-proxy Type:repository]]
error: Recipe `create-airgapped-bundle` failed with exit code 1
```

I don't have access to pull nutanix dockerhub private images but this should work from bundle repo.
