### PR TITLE
Add extra images for OpenTelemetry Collector

### DIFF
--- a/applications/opentelemetry-operator/0.102.0/helmrelease/extra-images.txt
+++ b/applications/opentelemetry-operator/0.102.0/helmrelease/extra-images.txt
@@ -1,0 +1,2 @@
+ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.141.0
+ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.141.0


### PR DESCRIPTION
Added extra-images.txt in otel operator application to also include otel collector images.
This is so that if used to create airgapped bundles all images for using otel operator and creating otel collectors are included.