### PR TITLE
Fix: kserve install failure on airgap

### DIFF
--- a/applications/kserve/0.15.0/helmrelease/kserve.yaml
+++ b/applications/kserve/0.15.0/helmrelease/kserve.yaml
@@ -27,10 +27,14 @@ spec:
   - name: kserve-crd
   interval: 15s
   install:
+    strategy:
+      name: RetryOnFailure
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    strategy:
+      name: RetryOnFailure
     remediation:
       retries: 30
   releaseName: kserve


### PR DESCRIPTION
HelmRelease to RetryOnFailure instead of cleanup and retry
Fixes - https://jira.nutanix.com/browse/NCN-114433

Kserve has some race condition and fails on initial install and goes through on retry - https://github.com/kserve/kserve/issues/5037

This PR makes HelmRelease to not cleanup and retry on failure.
Validated on airgap cluster.
