### PR TITLE
ci: update release tooling for airgapped bundles

### DIFF
--- a/just/release.just
+++ b/just/release.just
@@ -17,8 +17,10 @@ create-airgapped-bundle collection-tag output-file release-spec=".release/airgap
     exit 1
   fi
 
-  if ! yq '.releases[] | select(.tagName == "'$tag_version'")' {{release-spec}} > /dev/null 2>&1; then
-    echo "Error: Version '$tag_version' not found in {{release-spec}}"
+  airgapped_tag="${tag_version}.x-airgapped"
+
+  if [ -z "$(yq '.releases[] | select(.tagName == "'"$airgapped_tag"'")' {{release-spec}})" ]; then
+    echo "Error: Version '$airgapped_tag' not found in {{release-spec}}"
     exit 1
   fi
 
@@ -28,11 +30,11 @@ create-airgapped-bundle collection-tag output-file release-spec=".release/airgap
   cp {{ REPO_ROOT }}/.release/airgapped.yaml.tmpl "$tmpfile"
 
   yq -i \
-    '.releases[0].tagName = "'$tag_version'" |
+    '.releases[0].tagName = "'$airgapped_tag'" |
      .releases[0].fileName = "{{output-file}}" |
-     .releases[0].applications = (load("{{release-spec}}") | .releases[] | select(.tagName == "'$tag_version'") | .applications)' \
+     .releases[0].applications = (load("{{release-spec}}") | .releases[] | select(.tagName == "'"$airgapped_tag"'") | .applications)' \
     "$tmpfile"
 
-  echo "Building airgapped bundle for $tag_version..."
+  echo "Building airgapped bundle for $tag_version... (collection tag: $airgapped_tag)"
   cat "$tmpfile"
   "{{ NKP_CLI }}" experimental catalog release --release-spec "$tmpfile" --repo-dir "{{ REPO_ROOT }}"


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

Adjusting the airgapepd release tooling after recent changes to exclude NAI but include NDK. 

Tested locally (I used envoy cuz I do not have access to NDK images):

```
❯ just create-airgapped-bundle v2.18.0-rc.4 nutanix-product-catalog-v2.18.0-rc.4-airgapped.tar
Building airgapped bundle for 2.18... (collection tag: 2.18.x-airgapped)
# Airgapped release spec template
schema: catalog.nkp.nutanix.com/v1/catalog-release-spec
releases:
  - tagName: 2.18.x-airgapped
    fileName: nutanix-product-catalog-v2.18.0-rc.4-airgapped.tar
    includeApplicationImages: true
    baseRegistry: ghcr.io/nutanix-cloud-native
    applications:
      - name: envoy-gateway
        version: "1.5.0"
Building airgapped bundle "2.18.x-airgapped" (1 application(s)) -> /Users/tarun.akirala/git/organizations/nutanix-cloud-native/nkp-nutanix-product-catalog/nutanix-product-catalog-v2.18.0-rc.4-airgapped.tar

Processing application artifacts...
Processing application envoy-gateway/1.5.0
 ✓ K8s [1.33.0 1.34.0 1.35.0]: Parsing resources
 ✓ K8s v1.33.0: Validating
 ✓ K8s v1.34.0: Validating
 ✓ K8s v1.35.0: Validating
 ✓ Pulling requested images [====================================>4/4] (time elapsed 05s)

Saving bundle...
 ✓ Saving application bundle to /Users/tarun.akirala/git/organizations/nutanix-cloud-native/nkp-nutanix-product-catalog/nutanix-product-catalog-v2.18.0-rc.4-airgapped.tar
Generated file: nutanix-product-catalog-v2.18.0-rc.4-airgapped.tar
```

which upon extraction has:
```
❯ cat nkp-layout.yaml
applications:
- name: envoy-gateway
  version: 1.5.0
name: nkp-nutanix-product-catalog
tag: 2.18.x-airgapped
❯ cat images.yaml
docker.io:
  images:
    envoyproxy/gateway:
      - v1.5.0
    envoyproxy/gateway-helm:
      - v1.5.0
ghcr.io:
  images:
    nutanix-cloud-native/nkp-nutanix-product-catalog/collection:
      - 2.18.x-airgapped
    nutanix-cloud-native/nkp-nutanix-product-catalog/envoy-gateway:
      - 1.5.0
```