### PR TITLE
feat: update AI categories and app screens

### DIFF
--- a/applications/envoy-gateway-nai/1.7.0/metadata.yaml
+++ b/applications/envoy-gateway-nai/1.7.0/metadata.yaml
@@ -5,7 +5,10 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: ">=2.17.0"
 category:
-  - networking
+  - inferencing-and-serving
+appScreens:
+  - general
+  - ai
 certifications:
   - nutanix-supported
   - airgapped

--- a/applications/envoy-gateway/1.6.3/metadata.yaml
+++ b/applications/envoy-gateway/1.6.3/metadata.yaml
@@ -5,7 +5,10 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: ">=2.16.0"
 category:
-  - networking
+  - inferencing-and-serving
+appScreens:
+  - general
+  - ai
 certifications:
   - nutanix-supported
   - airgapped

--- a/applications/kserve/0.15.0/metadata.yaml
+++ b/applications/kserve/0.15.0/metadata.yaml
@@ -5,7 +5,9 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: ">=2.14.0"
 category:
-  - artificial-intelligence
+  - inferencing-and-serving
+appScreens:
+  - ai
 certifications:
   - nutanix-supported
   - airgapped

--- a/applications/nutanix-ai/2.4.0/metadata.yaml
+++ b/applications/nutanix-ai/2.4.0/metadata.yaml
@@ -5,7 +5,10 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: "<2.16.0"
 category:
-  - artificial-intelligence
+  - inferencing-and-serving
+appScreens:
+  - general
+  - ai
 certifications:
   - nutanix-supported
   - airgapped

--- a/applications/nutanix-ai/2.5.0/metadata.yaml
+++ b/applications/nutanix-ai/2.5.0/metadata.yaml
@@ -5,7 +5,10 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: "<2.17.0"
 category:
-  - artificial-intelligence
+  - inferencing-and-serving
+appScreens:
+  - general
+  - ai
 certifications:
   - nutanix-supported
   - airgapped

--- a/applications/nutanix-ai/2.6.0/metadata.yaml
+++ b/applications/nutanix-ai/2.6.0/metadata.yaml
@@ -5,7 +5,10 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: ">=2.16.0 <2.18.0"
 category:
-  - artificial-intelligence
+  - inferencing-and-serving
+appScreens:
+  - general
+  - ai
 certifications:
   - nutanix-supported
   - airgapped

--- a/applications/nutanix-ai/2.7.0/metadata.yaml
+++ b/applications/nutanix-ai/2.7.0/metadata.yaml
@@ -5,7 +5,10 @@ type: nkp-catalog
 allowMultipleInstances: false
 nkpVersionSupport: ">=2.17.1 <2.19.0"
 category:
-  - artificial-intelligence
+  - inferencing-and-serving
+appScreens:
+  - general
+  - ai
 certifications:
   - nutanix-supported
   - airgapped


### PR DESCRIPTION
Ticket:
https://jira.nutanix.com/secure/RapidBoard.jspa?rapidView=3430&view=detail&selectedIssue=NCN-115773#

Design doc:
https://docs.google.com/document/d/1NcHD4iEKczp2GX-gYNmRTSEkqnrVzW1QBnREISoFkek/edit?tab=t.0#heading=h.pnpnvh1kelv

## Summary
- Update `kserve`, `envoy-gateway`, and `envoy-gateway-nai` metadata to use AI subcategory values for 2.19 logic.
- Add `appScreens` so AI-only apps are shown only on AI screen and dual-screen apps are shown on both `general` and `ai`.

## Test plan
- [x] Run `devbox run pre-commit run --all-files`
- [x] Verify only intended metadata files changed
