### PR TITLE
ci: drop redundant action step

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -18,18 +18,6 @@ jobs:
     runs-on:
       - self-hosted-nutanix-medium
     steps:
-      # action-check-approvals (https://github.com/nutanix-cloud-native/action-check-approvals):
-      # Gates workflow on PRs until they have required approvals and labels. Ensures integration
-      # tests only run after maintainer sign-off. Requires PR to have one of: integration-test,
-      # skip_integration (default). Requires review_approvals_count approvals (default: 1).
-      # Uses @v1.0.1 tag for stability; use @main for latest (may break on upstream changes).
-      - name: Check integration test allowance status
-        if: github.event_name == 'pull_request'
-        id: check_approvals
-        uses: nutanix-cloud-native/action-check-approvals@v1.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Remove the `action-check-approvals` step from the manifest validation workflow as it is no longer needed

See: https://github.com/nutanix-cloud-native/nkp-ai-applications-catalog/pull/55

**Which issue(s) does this PR fix?**:
